### PR TITLE
OPEA mega-service initial config before opea-comps correct install

### DIFF
--- a/opea-comps/Readme.md
+++ b/opea-comps/Readme.md
@@ -32,3 +32,23 @@ curl http://localhost:8008/api/generate -d '{
 ### Docker Desktop considerations
 
 For the VSCode app to connect with the containers extensions, it's not only necessary install docker on WSL, but also have the docker desktop application running.
+
+
+## Mega-service Install considerations
+
+First, install PIP on WSL (if clean distro)
+
+```sh
+sudo apt install python3-pip
+```
+
+### Install requirements
+
+```
+pip install -r requirements.txt 
+```
+
+> **error**: externally-managed-environment
+
+Since I'm using a recently installed setup for WSL and Docker Desktop, when i try to install the opea-comps, an error prevents from using the package. 
+TODO: Check integration between WSL and Windows 11 with Docker Desktop installed.

--- a/opea-comps/mega-service/app.py
+++ b/opea-comps/mega-service/app.py
@@ -1,0 +1,33 @@
+from comps import MicroService, ServiceOrchestrator
+
+EMBEDDING_SERVICE_HOST_IP = os.getenv("EMBEDDING_SERVICE_HOST_IP", "0.0.0.0")
+EMBEDDING_SERVICE_PORT = os.getenv("EMBEDDING_SERVICE_PORT", 6000)
+LLM_SERVICE_HOST_IP = os.getenv("LLM_SERVICE_HOST_IP", "0.0.0.0")
+LLM_SERVICE_PORT = os.getenv("LLM_SERVICE_PORT", 9000)
+
+
+class ExampleService:
+    def __init__(self, host="0.0.0.0", port=8000):
+        self.host = host
+        self.port = port
+        self.megaservice = ServiceOrchestrator()
+
+    def add_remote_service(self):
+        embedding = MicroService(
+            name="embedding",
+            host=EMBEDDING_SERVICE_HOST_IP,
+            port=EMBEDDING_SERVICE_PORT,
+            endpoint="/v1/embeddings",
+            use_remote_service=True,
+            service_type=ServiceType.EMBEDDING,
+        )
+        llm = MicroService(
+            name="llm",
+            host=LLM_SERVICE_HOST_IP,
+            port=LLM_SERVICE_PORT,
+            endpoint="/v1/chat/completions",
+            use_remote_service=True,
+            service_type=ServiceType.LLM,
+        )
+        self.megaservice.add(embedding).add(llm)
+        self.megaservice.flow_to(embedding, llm)

--- a/opea-comps/mega-service/requirements.txt
+++ b/opea-comps/mega-service/requirements.txt
@@ -1,0 +1,1 @@
+opea-comps


### PR DESCRIPTION
Merge with initial mega-service config files, but with the error defined on issue #13.